### PR TITLE
Prevent Null Pointer Exception for some entities

### DIFF
--- a/src/main/java/daniel/mythicmania/entity/OrbiterEntity.java
+++ b/src/main/java/daniel/mythicmania/entity/OrbiterEntity.java
@@ -102,18 +102,18 @@ public class OrbiterEntity extends HostileEntity {
             projectile.setItem(charge);
             projectile.setVelocity(this.orbiter, this.orbiter.getPitch(), this.orbiter.getYaw(), 0.0F, 0.72F, 0F);
 
-            // TODO: Awkward. Rewrite
-            if (attackTarget != null) {
-                if (attackTarget.squaredDistanceTo(this.orbiter) < 81 && this.orbiter.canSee(attackTarget)) {
-                    ++this.cooldown;
+            if (attackTarget == null) return;
 
-                    if (this.cooldown == 15) {
-                        world.spawnEntity(projectile);
-                        this.cooldown = 0;
-                    }
-                } else if (this.cooldown > 0) {
-                    --this.cooldown;
+            // TODO: Awkward. Rewrite
+            if (attackTarget.squaredDistanceTo(this.orbiter) < 81 && this.orbiter.canSee(attackTarget)) {
+                ++this.cooldown;
+
+                if (this.cooldown == 15) {
+                    world.spawnEntity(projectile);
+                    this.cooldown = 0;
                 }
+            } else if (this.cooldown > 0) {
+                --this.cooldown;
             }
         }
     }

--- a/src/main/java/daniel/mythicmania/entity/ShockBoltEntity.java
+++ b/src/main/java/daniel/mythicmania/entity/ShockBoltEntity.java
@@ -33,14 +33,14 @@ public class ShockBoltEntity extends ThrownItemEntity {
         LightningEntity lightningEntity = EntityType.LIGHTNING_BOLT.create(world);
         BlockPos blockPos = target.getBlockPos();
 
-        if (lightningEntity != null) {
-            lightningEntity.refreshPositionAfterTeleport(Vec3d.ofBottomCenter(blockPos.up()));
-            lightningEntity.setChanneler(target instanceof ServerPlayerEntity ? (ServerPlayerEntity)target : null);
+        if (lightningEntity == null) return;
 
-            if (!world.isClient) {
-                ((LivingEntity) target).addStatusEffect(stunEffect);
-                world.spawnEntity(lightningEntity);
-            }
+        lightningEntity.refreshPositionAfterTeleport(Vec3d.ofBottomCenter(blockPos.up()));
+        lightningEntity.setChanneler(target instanceof ServerPlayerEntity ? (ServerPlayerEntity)target : null);
+
+        if (!world.isClient) {
+            ((LivingEntity) target).addStatusEffect(stunEffect);
+            world.spawnEntity(lightningEntity);
         }
 
         this.kill();


### PR DESCRIPTION
Adds a simple check - `if (thing) == null return;` in some places which prevents NPE.
Better than nesting the code in an `if (thing != null) {...}` statement because it improves readability.