### PR TITLE
Bump Wasted Demon health to 200hp

### DIFF
--- a/src/main/java/daniel/mythicmania/entity/WastedDemonEntity.java
+++ b/src/main/java/daniel/mythicmania/entity/WastedDemonEntity.java
@@ -136,7 +136,7 @@ public class WastedDemonEntity extends HostileEntity {
     public static DefaultAttributeContainer.Builder createWastedDemonAttributes() {
         return HostileEntity
                 .createHostileAttributes()
-                .add(EntityAttributes.GENERIC_MAX_HEALTH, 150)
+                .add(EntityAttributes.GENERIC_MAX_HEALTH, 200)
                 .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 35.0D)
                 .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.35D)
                 .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 7.0D)


### PR DESCRIPTION
After doing a couple battles with gear and such, I've concluded that 200 is probably the best health for the demon, considering the player has the advantages of the powerful staffs.