### PR TITLE
Add poison handling to nuclear set

### DIFF
--- a/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
+++ b/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
@@ -28,7 +28,7 @@ public abstract class MixinPlayerEntity extends LivingEntity {
 
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.updateTurtleHelmet()V"))
     private void mythicmania$injectDemonVestEffects(CallbackInfo ci) {
-        // TODO: Write more flexible system to avoid polluting this inject
+        // TODO: Write more flexible system to avoid polluting this inject, and clean up some of the code (like particle handling)
         ItemStack headSlotItem = this.getEquippedStack(EquipmentSlot.HEAD);
         ItemStack chestSlotItem = this.getEquippedStack(EquipmentSlot.CHEST);
         ItemStack legsSlotItem = this.getEquippedStack(EquipmentSlot.LEGS);

--- a/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
+++ b/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
@@ -9,6 +9,8 @@ import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -50,6 +52,21 @@ public abstract class MixinPlayerEntity extends LivingEntity {
             bootSlotItem.isOf(MythicManiaItems.NUCLEAR_BOOTS)
         ) {
             this.addStatusEffect(regeneration);
+
+            if (this.hasStatusEffect(StatusEffects.POISON)) {
+                this.removeStatusEffect(StatusEffects.POISON);
+
+                if (world.isClient) {
+                    World world = this.getWorld();
+                    BlockPos pos = this.getBlockPos();
+                    final double xPos = pos.getX() + random.nextDouble();
+                    final double yPos = pos.getY() + 0.6;
+                    final double zPos = pos.getZ() + random.nextDouble();
+
+                    world.addParticle(ParticleTypes.HEART, xPos, yPos, zPos, 0.0, -1, 0.0);
+                    world.addParticle(ParticleTypes.HEART, xPos, yPos, zPos, 0.0, -1, 0.0);
+                }
+            }
         }
 
         if (

--- a/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
+++ b/src/main/java/daniel/mythicmania/mixin/MixinPlayerEntity.java
@@ -38,13 +38,13 @@ public abstract class MixinPlayerEntity extends LivingEntity {
         final StatusEffectInstance fireResistance = new StatusEffectInstance(StatusEffects.FIRE_RESISTANCE, 40, 0, false, false, true);
         final StatusEffectInstance regeneration = new StatusEffectInstance(StatusEffects.REGENERATION, 40, 0, false, false, true);
 
-        // Gives player speed and fire resistance if demon vest is worn.
+        // Handle player when wearing demon vest
         if (chestSlotItem.isOf(MythicManiaItems.DEMON_VEST)) {
             this.addStatusEffect(speed);
             this.addStatusEffect(fireResistance);
         }
 
-        // Gives player regeneration if full intoxicated set is worn.
+        // Handle player when wearing nuclear set
         if (
             headSlotItem.isOf(MythicManiaItems.NUCLEAR_HELMET) &&
             chestSlotItem.isOf(MythicManiaItems.NUCLEAR_CHESTPLATE) &&
@@ -69,6 +69,7 @@ public abstract class MixinPlayerEntity extends LivingEntity {
             }
         }
 
+        // Handle player when wearing ruinous set
         if (
             headSlotItem.isOf(MythicManiaItems.RUINOUS_HELMET) ||
             chestSlotItem.isOf(MythicManiaItems.RUINOUS_CHESTPLATE) ||


### PR DESCRIPTION
Adds immunity to poison if full set is on.
Also, displays particles when player heals from poison effect with set on.